### PR TITLE
Release/0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,18 @@
 
 # Solon Changelog
 
-## [0.1.0]
+## [0.1.1]
 
 ### Updated
 
-- Only support IDEA 243.* version
-- Support configuration data hints and property navigation for yml and properties files
+- fix issues:
+    - Too many non-blocking read actions submitted at once. Please use coalesceBy, BoundedTaskExecutor or another way of
+      limiting the number of concurrently running threads.: 11 with similar stack traces are currently active
+    - No dependencies provided which causes CachedValue to be never recalculated again. If this is intentional, please
+      use
+      ModificationTracker.NEVER_CHANGED
 
-
-## [0.0.13]
+## [0.1.0]
 
 ### Updated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ pluginGroup=org.noear.solon.idea.plugin
 pluginName=Solon
 pluginRepositoryUrl=https://gitee.com/noear/solon-idea-plugin
 # SemVer format -> https://semver.org
-pluginVersion=0.1.0
+pluginVersion=0.1.1
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild=243
 pluginUntilBuild=251.*

--- a/src/main/java/org/noear/solon/idea/plugin/metadata/service/CompilationListener.java
+++ b/src/main/java/org/noear/solon/idea/plugin/metadata/service/CompilationListener.java
@@ -11,104 +11,104 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.task.ModuleBuildTask;
 import com.intellij.task.ProjectTaskListener;
 import com.intellij.task.ProjectTaskManager;
+import org.jetbrains.annotations.NotNull;
 import org.noear.solon.idea.plugin.metadata.source.MetadataFileIndex;
 import org.noear.solon.idea.plugin.misc.ModuleRootUtils;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 
 @SuppressWarnings("UnstableApiUsage")
 class CompilationListener implements CompilationStatusListener, ProjectTaskListener {
-  private final Project project;
+    private final Project project;
 
 
-  CompilationListener(Project project) {
-    this.project = project;
-  }
-
-
-  /**
-   * For Maven project only
-   * <p>
-   * {@inheritDoc}
-   */
-  @Override
-  public void compilationFinished(boolean aborted, int errors, int warnings, @NotNull CompileContext compileContext) {
-    enqueueBackgroundReloadTask(List.of(compileContext.getCompileScope().getAffectedModules()));
-  }
-
-
-  /**
-   * For gradle delegated build
-   * <p>
-   * {@inheritDoc}
-   */
-  @Override
-  public void finished(@NotNull ProjectTaskManager.Result result) {
-    if (result.isAborted()) return;
-    enqueueBackgroundReloadTask(getAffectedModules(result));
-  }
-
-
-  private Set<Module> getAffectedModules(ProjectTaskManager.Result result) {
-    Set<Module> modules = new HashSet<>();
-    result.anyTaskMatches((task, state) -> {
-      if (task instanceof ModuleBuildTask mbt && !state.isFailed() && !state.isSkipped()) {
-        modules.add(mbt.getModule());
-        return true;
-      } else {
-        return false;
-      }
-    });
-    return modules;
-  }
-
-
-  private void enqueueBackgroundReloadTask(Collection<Module> affectedModules) {
-    //The index recreates too late, we have to find the generated metadata files without the index.
-    new Task.Backgroundable(project, "Reloading solon configuration metadata") {
-      @Override
-      public void run(@NotNull ProgressIndicator indicator) {
-        indicator.pushState();
-        indicator.setIndeterminate(false);
-        List<VirtualFile> affectedClassRoots = new ArrayList<>();
-        double i = 0;
-        for (Module module : affectedModules) {
-          assert module.getProject().equals(project);   // The 2 topics we are listening are all project-level.
-          indicator.setText2(module.getName());
-          indicator.setFraction(i++ / affectedModules.size());
-          affectedClassRoots.addAll(Arrays.asList(ModuleRootUtils.getClassRootsWithoutLibraries(module)));
-        }
-        indicator.popState();
-        List<VirtualFile> newMetaFiles = affectedClassRoots.stream()
-            .map(MetadataFileIndex::findMetaFileInClassRoot)
-            .filter(Objects::nonNull)
-            .toList();
-        if (newMetaFiles.isEmpty()) return;
-        // Looks like the IDE won't reload the generated metadata file automatically,
-        // so we have to refresh it for use by IndexFromOneFile#reSync
-        newMetaFiles.forEach(vf -> vf.refresh(true, false));
-        i = 0;
-        for (Module module : affectedModules) {
-          indicator.setText2(module.getName());
-          indicator.setFraction(i++ / affectedModules.size());
-          refreshModuleAndDependencies(List.of(module), newMetaFiles);
-        }
-      }
-    }.queue();
-  }
-
-
-  private void refreshModuleAndDependencies(
-      Iterable<Module> modules, Collection<VirtualFile> additionalMetaFiles) {
-    for (Module module : modules) {
-      ModuleMetadataServiceImpl mms = (ModuleMetadataServiceImpl) module.getServiceIfCreated(
-          ModuleMetadataService.class);
-      if (mms != null) {
-        mms.refreshMetadata(additionalMetaFiles);
-      }
-      refreshModuleAndDependencies(ModuleManager.getInstance(project).getModuleDependentModules(module),
-          additionalMetaFiles);
+    CompilationListener(Project project) {
+        this.project = project;
     }
-  }
+
+
+    /**
+     * For Maven project only
+     * <p>
+     * {@inheritDoc}
+     */
+    @Override
+    public void compilationFinished(boolean aborted, int errors, int warnings, @NotNull CompileContext compileContext) {
+        enqueueBackgroundReloadTask("CompilationFinished", List.of(compileContext.getCompileScope().getAffectedModules()));
+    }
+
+
+    /**
+     * For gradle delegated build
+     * <p>
+     * {@inheritDoc}
+     */
+    @Override
+    public void finished(@NotNull ProjectTaskManager.Result result) {
+        if (result.isAborted()) return;
+        enqueueBackgroundReloadTask("Finished", getAffectedModules(result));
+    }
+
+
+    private Set<Module> getAffectedModules(ProjectTaskManager.Result result) {
+        Set<Module> modules = new HashSet<>();
+        result.anyTaskMatches((task, state) -> {
+            if (task instanceof ModuleBuildTask mbt && !state.isFailed() && !state.isSkipped()) {
+                modules.add(mbt.getModule());
+                return true;
+            } else {
+                return false;
+            }
+        });
+        return modules;
+    }
+
+
+    private void enqueueBackgroundReloadTask(String mark, Collection<Module> affectedModules) {
+        //The index recreates too late, we have to find the generated metadata files without the index.
+        new Task.Backgroundable(project, "%s Reloading solon configuration metadata".formatted(mark)) {
+            @Override
+            public void run(@NotNull ProgressIndicator indicator) {
+                indicator.pushState();
+                indicator.setIndeterminate(false);
+                List<VirtualFile> affectedClassRoots = new ArrayList<>();
+                double i = 0;
+                for (Module module : affectedModules) {
+                    assert module.getProject().equals(project);   // The 2 topics we are listening are all project-level.
+                    indicator.setText2(module.getName());
+                    indicator.setFraction(i++ / affectedModules.size());
+                    affectedClassRoots.addAll(Arrays.asList(ModuleRootUtils.getClassRootsWithoutLibraries(module)));
+                }
+                indicator.popState();
+                List<VirtualFile> newMetaFiles = affectedClassRoots.stream()
+                        .map(MetadataFileIndex::findMetaFileInClassRoot)
+                        .filter(Objects::nonNull)
+                        .toList();
+                if (newMetaFiles.isEmpty()) return;
+                // Looks like the IDE won't reload the generated metadata file automatically,
+                // so we have to refresh it for use by IndexFromOneFile#reSync
+                newMetaFiles.forEach(vf -> vf.refresh(true, false));
+                i = 0;
+                for (Module module : affectedModules) {
+                    indicator.setText2(module.getName());
+                    indicator.setFraction(i++ / affectedModules.size());
+                    refreshModuleAndDependencies(List.of(module), newMetaFiles);
+                }
+            }
+        }.queue();
+    }
+
+
+    private void refreshModuleAndDependencies(
+            Iterable<Module> modules, Collection<VirtualFile> additionalMetaFiles) {
+        for (Module module : modules) {
+            ModuleMetadataServiceImpl mms = (ModuleMetadataServiceImpl) module.getServiceIfCreated(
+                    ModuleMetadataService.class);
+            if (mms != null) {
+                mms.refreshMetadata(additionalMetaFiles);
+            }
+            refreshModuleAndDependencies(ModuleManager.getInstance(project).getModuleDependentModules(module),
+                    additionalMetaFiles);
+        }
+    }
 }

--- a/src/main/java/org/noear/solon/idea/plugin/metadata/service/MetadataStartupActivity.java
+++ b/src/main/java/org/noear/solon/idea/plugin/metadata/service/MetadataStartupActivity.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.ProjectActivity;
+import com.intellij.util.ArrayUtil;
 import com.intellij.util.concurrency.AppExecutorUtil;
 import kotlin.Unit;
 import kotlin.coroutines.Continuation;
@@ -18,7 +19,9 @@ public class MetadataStartupActivity implements ProjectActivity {
         // 使用后台线程执行耗时操作
         DumbService.getInstance(project).runWhenSmart(() -> {
             ReadAction.nonBlocking(() -> {
-                        for (Module module : ModuleManager.getInstance(project).getModules()) {
+                        Module[] modules = ModuleManager.getInstance(project).getModules();
+                        if (!ArrayUtil.isEmpty(modules)) {
+                            Module module = modules[0];
                             ModuleMetadataService service = module.getService(ModuleMetadataService.class);
                             if (service instanceof ModuleMetadataServiceImpl impl) {
                                 impl.refreshMetadata();

--- a/src/main/java/org/noear/solon/idea/plugin/metadata/service/ModuleDependenciesWatcher.java
+++ b/src/main/java/org/noear/solon/idea/plugin/metadata/service/ModuleDependenciesWatcher.java
@@ -42,7 +42,7 @@ class ModuleDependenciesWatcher implements WorkspaceModelChangeListener {
             }
         }
         if (!interested.isEmpty()) {
-            new Task.Backgroundable(project, "Reloading slon configuration metadata") {
+            new Task.Backgroundable(project, "Changed Reloading solon configuration metadata") {
                 @Override
                 public void run(@NotNull ProgressIndicator indicator) {
                     indicator.setIndeterminate(false);


### PR DESCRIPTION
- fix issues:
    - Too many non-blocking read actions submitted at once. Please use coalesceBy, BoundedTaskExecutor or another way of
      limiting the number of concurrently running threads.: 11 with similar stack traces are currently active
    - No dependencies provided which causes CachedValue to be never recalculated again. If this is intentional, please
      use
      ModificationTracker.NEVER_CHANGED