### PR TITLE
优化 Solon 文件类型配置，移除扩展名限制以避免与通用文件类型冲突

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -33,14 +33,12 @@
                   implementationClass="org.noear.solon.idea.plugin.filetype.SolonPropertiesFileType"
                   fieldName="INSTANCE"
                   fileNames="app.properties"
-                  extensions="properties"
                   patterns="app-*.properties"/>
 
         <fileType name="solon-yaml-file"
                   implementationClass="org.noear.solon.idea.plugin.filetype.SolonYamlFileType"
                   fieldName="INSTANCE"
                   fileNames="app.yaml;app.yml"
-                  extensions="yaml,yml"
                   patterns="app-*.yaml;app-*.yml"/>
 
         <psi.referenceContributor


### PR DESCRIPTION
- 移除 SolonPropertiesFileType 的 extensions="properties" 配置
- 移除 SolonYamlFileType 的 extensions="yaml,yml" 配置
- 保留 fileNames 和 patterns 配置确保准确的文件类型识别

🤖 Generated with [Claude Code](https://claude.com/claude-code)